### PR TITLE
Stronger V4L2 UAPI compliance in format negotation and stream activation

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -1743,7 +1743,11 @@ static int vidioc_querybuf(struct file *file, void *fh, struct v4l2_buffer *buf)
 
 	buf->type = type;
 
-	if (V4L2_TYPE_IS_CAPTURE(type)) {
+	if (!(buf->flags & (V4L2_BUF_FLAG_DONE | V4L2_BUF_FLAG_QUEUED))) {
+		/* v4l2-compliance requires these to be zero */
+		buf->sequence = 0;
+		buf->timestamp.tv_sec = buf->timestamp.tv_usec = 0;
+	} else if (V4L2_TYPE_IS_CAPTURE(type)) {
 		/* guess flags based on sequence values */
 		if (buf->sequence >= opener->read_position) {
 			set_done(buf->flags);

--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -1880,11 +1880,15 @@ static int vidioc_dqbuf(struct file *file, void *fh, struct v4l2_buffer *buf)
 	case V4L2_BUF_TYPE_VIDEO_OUTPUT:
 		spin_lock_bh(&dev->list_lock);
 
-		b = list_first_entry(&dev->outbufs_list, struct v4l2l_buffer,
-				     list_head);
-		list_move_tail(&b->list_head, &dev->outbufs_list);
+		b = list_first_entry_or_null(&dev->outbufs_list,
+					     struct v4l2l_buffer, list_head);
+
+		if (b)
+			list_move_tail(&b->list_head, &dev->outbufs_list);
 
 		spin_unlock_bh(&dev->list_lock);
+		if (!b)
+			return -EFAULT;
 		dprintkrw("output DQBUF index: %d\n", b->buffer.index);
 		unset_flags(b);
 		*buf = b->buffer;

--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -508,18 +508,13 @@ static int v4l2l_fill_format(struct v4l2_format *fmt, const u32 minwidth,
 	u32 pixelformat = fmt->fmt.pix.pixelformat;
 	struct v4l2_format fmt0 = *fmt;
 	u32 bytesperline = 0, sizeimage = 0;
+
 	if (!width)
 		width = V4L2LOOPBACK_SIZE_DEFAULT_WIDTH;
 	if (!height)
 		height = V4L2LOOPBACK_SIZE_DEFAULT_HEIGHT;
-	if (width < minwidth)
-		width = minwidth;
-	if (width > maxwidth)
-		width = maxwidth;
-	if (height < minheight)
-		height = minheight;
-	if (height > maxheight)
-		height = maxheight;
+	width = clamp_val(width, minwidth, maxwidth);
+	height = clamp_val(height, minheight, maxheight);
 
 	/* sets: width,height,pixelformat,bytesperline,sizeimage */
 	if (!(V4L2_TYPE_IS_MULTIPLANAR(fmt0.type))) {
@@ -2942,15 +2937,8 @@ static int v4l2_loopback_add(struct v4l2_loopback_config *conf, int *ret_nr)
 	/* FIXME set buffers to 0 */
 
 	/* Set initial format */
-	if (_width < _min_width)
-		_width = _min_width;
-	if (_width > _max_width)
-		_width = _max_width;
-	if (_height < _min_height)
-		_height = _min_height;
-	if (_height > _max_height)
-		_height = _max_height;
-
+	_width = clamp_val(_width, _min_width, _max_width);
+	_height = clamp_val(_height, _min_height, _max_height);
 	_fmt = (struct v4l2_format){
 		.type = V4L2_BUF_TYPE_VIDEO_CAPTURE,
 		.fmt.pix = { .width = _width,

--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -1170,11 +1170,9 @@ static int vidioc_g_fmt_cap(struct file *file, void *fh, struct v4l2_format *f)
 {
 	struct v4l2_loopback_device *dev = v4l2loopback_getdevice(file);
 	struct v4l2_loopback_opener *opener = fh_to_opener(fh);
-	MARK();
 	if (check_buffer_capability(dev, opener, f->type) < 0)
 		return -EINVAL;
 	f->fmt.pix = dev->pix_format;
-	MARK();
 	return 0;
 }
 
@@ -1203,8 +1201,6 @@ static int vidioc_g_fmt_out(struct file *file, void *fh, struct v4l2_format *f)
 {
 	struct v4l2_loopback_device *dev = v4l2loopback_getdevice(file);
 	struct v4l2_loopback_opener *opener = fh_to_opener(fh);
-	MARK();
-
 	if (check_buffer_capability(dev, opener, f->type) < 0)
 		return -EINVAL;
 	/*
@@ -1214,7 +1210,6 @@ static int vidioc_g_fmt_out(struct file *file, void *fh, struct v4l2_format *f)
 	 * CHECK whether this assumption is wrong,
 	 * or whether we have to always provide a valid format
 	 */
-
 	f->fmt.pix = dev->pix_format;
 	return 0;
 }
@@ -1265,7 +1260,6 @@ static int vidioc_g_parm(struct file *file, void *fh,
 	 * compatible */
 	struct v4l2_loopback_device *dev = v4l2loopback_getdevice(file);
 	struct v4l2_loopback_opener *opener = fh_to_opener(fh);
-	MARK();
 	if (check_buffer_capability(dev, opener, parm->type) < 0)
 		return -EINVAL;
 	parm->parm.capture = dev->capture_param;
@@ -1281,7 +1275,6 @@ static int vidioc_s_parm(struct file *file, void *fh,
 {
 	struct v4l2_loopback_device *dev = v4l2loopback_getdevice(file);
 	struct v4l2_loopback_opener *opener = fh_to_opener(fh);
-	MARK();
 
 	dprintk("vidioc_s_parm called frate=%u/%u\n",
 		parm->parm.capture.timeperframe.numerator,
@@ -1423,7 +1416,6 @@ static int vidioc_enum_output(struct file *file, void *fh,
 	__u32 index = outp->index;
 	struct v4l2_loopback_device *dev = v4l2loopback_getdevice(file);
 	struct v4l2_loopback_opener *opener = fh_to_opener(fh);
-	MARK();
 
 	if (check_buffer_capability(dev, opener, V4L2_BUF_TYPE_VIDEO_OUTPUT))
 		return -ENOTTY;
@@ -1484,7 +1476,6 @@ static int vidioc_enum_input(struct file *file, void *fh,
 	struct v4l2_loopback_device *dev = v4l2loopback_getdevice(file);
 	struct v4l2_loopback_opener *opener = fh_to_opener(fh);
 	__u32 index = inp->index;
-	MARK();
 
 	if (check_buffer_capability(dev, opener, V4L2_BUF_TYPE_VIDEO_CAPTURE))
 		return -ENOTTY;
@@ -1635,7 +1626,6 @@ static int vidioc_reqbufs(struct file *file, void *fh,
 			    token_from_type(reqbuf->type);
 	u32 req_count = reqbuf->count;
 	int result = 0;
-	MARK();
 
 	dprintk("REQBUFS(memory=%u, req_count=%u) and device-bufs=%u/%u "
 		"[used/max]\n",
@@ -1762,7 +1752,6 @@ static int vidioc_querybuf(struct file *file, void *fh, struct v4l2_buffer *buf)
 	struct v4l2_loopback_opener *opener = fh_to_opener(fh);
 	u32 type = buf->type;
 	u32 index = buf->index;
-	MARK();
 
 	if ((type != V4L2_BUF_TYPE_VIDEO_CAPTURE) &&
 	    (type != V4L2_BUF_TYPE_VIDEO_OUTPUT))
@@ -2029,7 +2018,6 @@ static int vidioc_streamon(struct file *file, void *fh, enum v4l2_buf_type type)
 	struct v4l2_loopback_device *dev = v4l2loopback_getdevice(file);
 	struct v4l2_loopback_opener *opener = fh_to_opener(fh);
 	u32 token = token_from_type(type);
-	MARK();
 
 	/* short-circuit when using timeout buffer set */
 	if (opener->format_token & V4L2L_TOKEN_TIMEOUT)
@@ -2065,8 +2053,6 @@ static int vidioc_streamoff(struct file *file, void *fh,
 	struct v4l2_loopback_device *dev = v4l2loopback_getdevice(file);
 	struct v4l2_loopback_opener *opener = fh_to_opener(fh);
 	u32 token = token_from_type(type);
-	MARK();
-	dprintk("%d\n", type);
 
 	/* short-circuit when using timeout buffer set */
 	if (opener->format_token & V4L2L_TOKEN_TIMEOUT)
@@ -2297,7 +2283,6 @@ static unsigned int v4l2_loopback_poll(struct file *file,
 	struct v4l2_loopback_opener *opener = fh_to_opener(file->private_data);
 	__poll_t req_events = poll_requested_events(pts);
 	int ret_mask = 0;
-	MARK();
 
 	/* call poll_wait in first call, regardless, to ensure that the
 	 * wait-queue is not null */
@@ -2331,7 +2316,6 @@ static unsigned int v4l2_loopback_poll(struct file *file,
 		break;
 	}
 
-	MARK();
 	return ret_mask;
 }
 
@@ -2341,7 +2325,7 @@ static int v4l2_loopback_open(struct file *file)
 {
 	struct v4l2_loopback_device *dev;
 	struct v4l2_loopback_opener *opener;
-	MARK();
+
 	dev = v4l2loopback_getdevice(file);
 	if (dev->open_count.counter >= dev->max_openers)
 		return -EBUSY;
@@ -2361,7 +2345,6 @@ static int v4l2_loopback_open(struct file *file)
 	v4l2_fh_add(&opener->fh);
 	dprintk("open() -> dev@%p with image@%p\n", dev,
 		dev ? dev->image : NULL);
-	MARK();
 	return 0;
 }
 
@@ -2370,7 +2353,6 @@ static int v4l2_loopback_close(struct file *file)
 	struct v4l2_loopback_device *dev = v4l2loopback_getdevice(file);
 	struct v4l2_loopback_opener *opener = fh_to_opener(file->private_data);
 	int result = 0;
-	MARK();
 	dprintk("close() -> dev@%p with image@%p\n", dev,
 		dev ? dev->image : NULL);
 
@@ -2413,7 +2395,6 @@ static int v4l2_loopback_close(struct file *file)
 	v4l2_fh_exit(&opener->fh);
 
 	kfree(opener);
-	MARK();
 	return 0;
 }
 
@@ -2558,7 +2539,6 @@ static int allocate_buffers(struct v4l2_loopback_device *dev,
 	u32 buffer_size = PAGE_ALIGN(pix_format->sizeimage);
 	unsigned long image_size =
 		(unsigned long)buffer_size * (unsigned long)dev->buffer_count;
-	MARK();
 	/* vfree on close file operation in case no open handles left */
 
 	if (buffer_size == 0 || dev->buffer_count == 0 ||
@@ -2627,7 +2607,6 @@ static void init_buffers(struct v4l2_loopback_device *dev, u32 bytes_used,
 			 u32 buffer_size)
 {
 	u32 i;
-	MARK();
 
 	for (i = 0; i < dev->buffer_count; ++i) {
 		struct v4l2_buffer *b = &dev->buffers[i].buffer;
@@ -2647,14 +2626,11 @@ static void init_buffers(struct v4l2_loopback_device *dev, u32 bytes_used,
 	}
 	dev->timeout_buffer = dev->buffers[0];
 	dev->timeout_buffer.buffer.m.offset = MAX_BUFFERS * buffer_size;
-	MARK();
 }
 
 /* fills and register video device */
 static void init_vdev(struct video_device *vdev, int nr)
 {
-	MARK();
-
 #ifdef V4L2LOOPBACK_WITH_STD
 	vdev->tvnorms = V4L2_STD_ALL;
 #endif /* V4L2LOOPBACK_WITH_STD */
@@ -2675,14 +2651,11 @@ static void init_vdev(struct video_device *vdev, int nr)
 				  V4L2_DEV_DEBUG_IOCTL_ARG;
 
 	vdev->vfl_dir = VFL_DIR_M2M;
-
-	MARK();
 }
 
 /* init default capture parameters, only fps may be changed in future */
 static void init_capture_param(struct v4l2_captureparm *capture_param)
 {
-	MARK();
 	capture_param->capability = V4L2_CAP_TIMEPERFRAME; /* since 2.16 */
 	capture_param->capturemode = 0;
 	capture_param->extendedmode = 0;
@@ -3081,12 +3054,11 @@ static long v4l2loopback_control_ioctl(struct file *file, unsigned int cmd,
 		if ((device_nr != output_nr) && (output_nr >= 0) &&
 		    ((ret = v4l2loopback_lookup(output_nr, 0)) < 0))
 			break;
-		MARK();
 
 		/* v4l2_loopback_config identified a single device, so fetch the data */
 		snprintf(conf.card_label, sizeof(conf.card_label), "%s",
 			 dev->card_label);
-		MARK();
+
 		conf.output_nr = dev->vdev->num;
 #ifdef SPLIT_DEVICES
 		conf.capture_nr = dev->vdev->num;
@@ -3104,13 +3076,10 @@ static long v4l2loopback_control_ioctl(struct file *file, unsigned int cmd,
 			ret = -EFAULT;
 			break;
 		}
-		MARK();
 		ret = 0;
-		;
 		break;
 	}
 
-	MARK();
 	mutex_unlock(&v4l2loopback_ctl_mutex);
 	MARK();
 	return ret;

--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -104,6 +104,7 @@ static inline void v4l2l_get_timestamp(struct v4l2_buffer *b)
 	b->timestamp.tv_sec = ts.tv_sec;
 	b->timestamp.tv_usec = (ts.tv_nsec / NSEC_PER_USEC);
 	b->flags |= V4L2_BUF_FLAG_TIMESTAMP_MONOTONIC;
+	b->flags &= ~V4L2_BUF_FLAG_TIMESTAMP_COPY;
 }
 
 #if BITS_PER_LONG == 32
@@ -1866,6 +1867,8 @@ static int vidioc_qbuf(struct file *file, void *fh, struct v4l2_buffer *buf)
 		} else {
 			bufd->buffer.timestamp = buf->timestamp;
 			bufd->buffer.flags |= V4L2_BUF_FLAG_TIMESTAMP_COPY;
+			bufd->buffer.flags &=
+				~V4L2_BUF_FLAG_TIMESTAMP_MONOTONIC;
 		}
 		if (dev->pix_format_has_valid_sizeimage) {
 			if (buf->bytesused >= dev->pix_format.sizeimage) {

--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -2235,12 +2235,11 @@ static int v4l2_loopback_close(struct file *file)
 	if (READER == opener->type)
 		is_reader = 1;
 
-	atomic_dec(&dev->open_count);
-	if (dev->open_count.counter == 0) {
+	if (atomic_dec_and_test(&dev->open_count)) {
 		del_timer_sync(&dev->sustain_timer);
 		del_timer_sync(&dev->timeout_timer);
+		try_free_buffers(dev);
 	}
-	try_free_buffers(dev);
 
 	v4l2_fh_del(&opener->fh);
 	v4l2_fh_exit(&opener->fh);

--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -2602,14 +2602,12 @@ static int v4l2_loopback_add(struct v4l2_loopback_config *conf, int *ret_nr)
 	u32 _max_height =
 		DEFAULT_FROM_CONF(max_height, < _min_height, max_height);
 	bool _announce_all_caps = (conf && conf->announce_all_caps >= 0) ?
-					  (conf->announce_all_caps) :
-					  V4L2LOOPBACK_DEFAULT_EXCLUSIVECAPS;
+					  (bool)(conf->announce_all_caps) :
+					  !(V4L2LOOPBACK_DEFAULT_EXCLUSIVECAPS);
 	int _max_buffers = DEFAULT_FROM_CONF(max_buffers, <= 0, max_buffers);
 	int _max_openers = DEFAULT_FROM_CONF(max_openers, <= 0, max_openers);
 
 	int nr = -1;
-
-	_announce_all_caps = (!!_announce_all_caps);
 
 	if (conf) {
 		const int output_nr = conf->output_nr;

--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -1592,6 +1592,7 @@ static int vidioc_reqbufs(struct file *file, void *fh,
 		if (b->count > dev->buffers_number)
 			b->count = dev->buffers_number;
 
+		spin_lock_bh(&dev->list_lock);
 		/* make sure that outbufs_list contains buffers from 0 to used_buffers-1
 		 * actually, it will have been already populated via v4l2_loopback_init()
 		 * at this point */
@@ -1622,6 +1623,7 @@ static int vidioc_reqbufs(struct file *file, void *fh,
 				++i;
 			}
 		}
+		spin_unlock_bh(&dev->list_lock);
 
 		opener->buffers_number = b->count;
 		if (opener->buffers_number < dev->used_buffers)

--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -389,7 +389,6 @@ struct v4l2_loopback_opener {
 	s64 read_position; /* number of last processed frame + 1 or
 			    * write_position - 1 if reader went out of sync */
 	unsigned int reread_count;
-	struct v4l2_buffer *buffers;
 	int buffers_number; /* should not be big, 4 is a good choice */
 	int timeout_image_io;
 

--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -1801,8 +1801,10 @@ static int vidioc_qbuf(struct file *file, void *fh, struct v4l2_buffer *buf)
 		return -EINVAL;
 	}
 
-	if (opener->io_method == V4L2L_IO_TIMEOUT)
+	if (opener->io_method == V4L2L_IO_TIMEOUT) {
+		set_queued(buf->flags);
 		return 0;
+	}
 
 	switch (type) {
 	case V4L2_BUF_TYPE_VIDEO_CAPTURE:
@@ -1930,6 +1932,8 @@ static int vidioc_dqbuf(struct file *file, void *fh, struct v4l2_buffer *buf)
 		return -EINVAL;
 	if (opener->io_method == V4L2L_IO_TIMEOUT) {
 		*buf = dev->timeout_buffer.buffer;
+		buf->type = type;
+		unset_flags(buf->flags);
 		return 0;
 	}
 

--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -287,8 +287,8 @@ static const struct v4l2_ctrl_config v4l2loopback_ctrl_timeoutimageio = {
 	.name	= "timeout_image_io",
 	.type	= V4L2_CTRL_TYPE_BUTTON,
 	.min	= 0,
-	.max	= 1,
-	.step	= 1,
+	.max	= 0,
+	.step	= 0,
 	.def	= 0,
 	// clang-format on
 };

--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -1880,8 +1880,8 @@ static int vidioc_dqbuf(struct file *file, void *fh, struct v4l2_buffer *buf)
 	case V4L2_BUF_TYPE_VIDEO_OUTPUT:
 		spin_lock_bh(&dev->list_lock);
 
-		b = list_entry(dev->outbufs_list.prev, struct v4l2l_buffer,
-			       list_head);
+		b = list_first_entry(&dev->outbufs_list, struct v4l2l_buffer,
+				     list_head);
 		list_move_tail(&b->list_head, &dev->outbufs_list);
 
 		spin_unlock_bh(&dev->list_lock);


### PR DESCRIPTION
Originally raised in #598.  The goal is to improve compliance with the V4L2 UAPI; specifically:

-   [Data Format Negotiation](https://www.kernel.org/doc/html/v6.13/userspace-api/media/v4l/format.html#data-format-negotiation):
    > The [VIDIOC_S_FMT](https://www.kernel.org/doc/html/v6.13/userspace-api/media/v4l/vidioc-g-fmt.html#vidioc-g-fmt) ioctl is a major turning-point in the initialization sequence ... The first [VIDIOC_S_FMT](https://www.kernel.org/doc/html/v6.13/userspace-api/media/v4l/vidioc-g-fmt.html#vidioc-g-fmt) assigns a logical stream (video data, VBI data etc.) exclusively to one file descriptor.
    
    And;
    > When applications omit the [VIDIOC_S_FMT](https://www.kernel.org/doc/html/v6.13/userspace-api/media/v4l/vidioc-g-fmt.html#vidioc-g-fmt) ioctl its locking side effects are implied by the next step, the selection of an I/O method with the [ioctl VIDIOC_REQBUFS](https://www.kernel.org/doc/html/v6.13/userspace-api/media/v4l/vidioc-reqbufs.html#vidioc-reqbufs) ioctl or implicit with the first [read()](https://www.kernel.org/doc/html/v6.13/userspace-api/media/v4l/func-read.html#c.V4L.read) or [write()](https://www.kernel.org/doc/html/v6.13/userspace-api/media/v4l/func-write.html#c.V4L.write) call ... only one logical stream can be assigned to a file descriptor.

-   [ioctl VIDIOC_REQBUFS](https://www.kernel.org/doc/html/v6.13/userspace-api/media/v4l/vidioc-reqbufs.html):
    > Applications can call [ioctl VIDIOC_REQBUFS](https://www.kernel.org/doc/html/v6.13/userspace-api/media/v4l/vidioc-reqbufs.html#vidioc-reqbufs) again to change the number of buffers .... A count value of zero frees or orphans all buffers, after aborting or finishing any DMA in progress, an implicit [VIDIOC_STREAMOFF](https://www.kernel.org/doc/html/v6.13/userspace-api/media/v4l/vidioc-streamon.html#vidioc-streamon).
    
    If the buffers are mapped and an attempt is made to re-allocate; then REQBUFS should return EBUSY.

-   [Input/Output](https://www.kernel.org/doc/html/v6.13/userspace-api/media/v4l/io.html):
    > Generally exactly one I/O method, including overlay, is associated with each file descriptor.

This first appeared as an issue in [some earlier experiments I was doing with __tiagocoutinho/linuxpy__](https://github.com/tiagocoutinho/linuxpy/pull/52).


## Summary

An opener now takes exclusive (and unique) control of a logical stream from a __v4l2-loopback__ node when S_FMT or REQBUFS is called. The three logical streams of a node include; video output, video capture, and timeout images. Changing the format of a node is only possible when either;

-   the opener owns a stream and all other streams are owned by the node, or;
-   all streams are owned by the node.

When this is the case: the enumeration and query controls of the node report all available formats, frame sizes, intervals (unless `keep_format` is set).

If this is not the case: the opener can S_FMT or REQBUFS to take control of an available stream, but they have to accept the node's existing format. This is because the two streams _must_ share the same format (no internal conversion). Enumeration of formats and frame sizes is restricted to the node's existing (locked) values.

For example;

-   Application `A` opens the node, and calls S_FMT with V4L2_BUF_TYPE_VIDEO_CAPTURE.
    -   `A` now controls the video capture stream, and has set the format for the node.
-  `A` enumerates all formats and successfully set a new format via S_FMT.
-   Application `B` opens the node and calls S_FMT with V4L2_BUF_TYPE_VIDEO_OUTPUT and any pixel format.
    -   `B` now controls the video output stream, but must accept the existing format returned by S_FMT.
-   `A` changes its mind and calls S_FMT again, but because `B` owns a stream, `A` get an EBUSY - the format cannot be changed.

Similarly, the first call to REQBUFS will lock the format. It _also_ has the effect of locking the number of buffers with similar semantics as above - that is to say; provided no other openers have control of a logical stream, the number of buffers can be altered. Otherwise, the existing number of buffers is preserved.

The stream that an opener controls can be released via REQBUFS with `count = 0`, or it can be changed via S_FMT.

Another form of locking occurs when an application calls REQBUFS: the application must use memory-mapped I/O from this point on - it cannot call `read()` or `write()`.

Similarly, a call to `read()` or `write()` _also_ assigns control of a logical stream to the application just like REQBUFS (in fact, they do so via REQBUFS and STREAMON). Furthermore, a call to `read()` or `write()` prevents the application from using memory-mapped I/O explicitly (e.g. QBUF, DQBUF, etc).

Up until QBUF and DQBUF; we are fully V4L2 UAPI compliant (with the caveat that a node should not support video output and video capture).

The timeout-image buffer cannot be accessed via `read()` and `write()` file I/O. Calls to S_FMT or REQBUFS _will_ behave as per the other streams with regards to 'locking' the format of the node. QBUF and DQBUF passively return the same (timeout) buffer. STREAMON and STREAMOFF have no effect. Only a change in format or release of the node will cause the timeout buffer to be released i.e. it is "set and forget".


## Technical summary

This results in a many changes in the __v4l2-loopback__ source.

The big picture is that the device now has "tokens" for video output, video capture, and timeout-image streams (or 'buffer sets'). These are acquired and released by openers upon calls to S_FMT or REQBUFS.

A similar set of tokens is used to track whether each stream is _active_ (i.e. STREAMON has been called) or _stopped_. These are acquired and released through STREAMON and STREAMOFF. The `exclusive_caps` feature now has side effects of disabling certain output and capture ioctls (ENOTTY) (see the function `check_buffer_capability()`), along with its effect on 'device capabilities'.

Here's a guide to some of the main (and minor-but-helpful) changes:

1.  (minor) Tidied some repeated string formatting for FOURCC (673e626a8) and debug print strings (83dc1590c, 77848dc3b, and b95cbd8ec).
2.  Safer list access in REQBUFs (04b4cafa8 and f900b8d62).
3.  Safer use of atomic operators for `open_count` in `close()` (c8c700306).
4.  (minor) Fixed __v4l2-compliance__ result `timeout_image_io` CTRL (22a165845), assignment of exclusive caps via __v4l2loopback-ctl__ (45d902ec3), and __v4l2-compliance__ result for frame interval controls (02cd9bc0e).
5.  (minor) Set a valid pix_format, e.g. `sizeimage`, in `add()` (0262d7644).
6. REQBUFS: count = 0 does STREAMOFF (dd12fa932).
7. Set I/O method for opener in read/write or REQBUFS (d045ae78f).
8. Switch on/off controls depending on availability of video capture or video output (b843ad155).
9. (__major__): S_FMT and REQBUFS control acquisition (and release) of token for logical stream (d93ea0055 and 51f680e8c <- the big one).
10. (minor): Set unique timestamp flags (for __v4l2-compliance__) (525b3b319).


## Bugs fixed

_System_: __Ubuntu__ 24.04, __GStreamer__ 1.24.2, kernel (`uname -r`) 6.8.0-52-generic

I was able to reproduce, and then confirm resolution of the following issues: i.e. fixes #121, fixes #334, fixes #598, fixes #607, fixes #610, and fixes #612 (with some changes to __v4l2loopback-ctl__ that I will submit).

It is now possible to resolve #251 and resolve #541 (and potentially other __GStreamer__ failures) by setting `max_buffers=3` or higher.

I also tested for regression of issue #60 and #83 and passed.


## Testing

### __v4l2-compliance__ results

_System_: __Ubuntu__ 24.04, __GStreamer__ 1.24.2, kernel (`uname -r`) 6.8.0-52-generic

Device started with `max_buffers=3` (minimum required for __GStreamer__ without `tee`). `exclusive_caps` either on or off, and with or without a writer attached via `gst-launch-1.0 videotestsrc ! v4l2sink device=/dev/video10`, (PASS/FAILED):

| exclusive_caps | 0 | 1 |
|------------|---|---|
| no writer | 45/3 | 47/1 |
| writer attached | 41/6 | 47/1 |


### Basic usage

Tested on three amd64 "machines" (kernel via `uname -r`):

-   __Ubuntu__ 24.04 Noble, __GStreamer__ 1.24.2, kernel  6.8.0-52-generic
-   __Debian__ 11 Bullseye, __GStreamer__ 1.18.4, kernel 5.10.0-33-amd64
-   __Ubuntu__ 16.04 Xenial, __GStreamer__ 0.10.36 and 1.8.3, kernel 4.15.0-142-generic

Selected results:

1.  ✅ ✅ ✅ read/write with `video_nr=10` and `exclusive_caps` on or off:
    ```
    ./tests/producer -d /dev/video10 -c 100 --write &
    ./tests/consumer -d /dev/video10 -c 10 --read
    ```

2.  ✅ ✅ ✅ basic __GStreamer__ usage, with `video_nr=10`, `max_buffers >= 3` (else insert `identity drop-allocation=1` element), and `exclusive_caps` on or off:
    ```
    gst-launch-1.0 videotestsrc ! v4l2sink device=/dev/video10
    gst-launch-1.0 v4l2src device=/dev/video10 ! videoconvert ! autovideosink
    ```
    
3.  ✅ ✅ ❌ `.examples/restarting_writers.sh` _and_ `v4l2loopback set-timeout-image` via #614 with `video_nr=10` and `exclusive_caps=0` (`exclusive_caps=1` and `keep_format` censors OUTPUT capability) - using [camera-not-found.jpeg 🔗](https://github.com/user-attachments/assets/eeeb9302-8f14-45b1-9371-46f1fbe0df1c). _Xenial: cannot set timeout image with __GStreamer__ < 1.16_.
    ```sh
    sudo ./examples/restarting_writer.sh /dev/video10
    # new terminal
    sudo v4l2loopback-ctl set-timeout-image -t 2000 /dev/video10 camera-not-found.jpeg
    ```


### In-the-wild usage

Tested on __Ubuntu__ 24.04 Noble, __GStreamer__ 1.24.2, kernel  6.8.0-52-generic, with `max_buffers=3`, and fed via `gst-launch-1.0 videotestsrc ! v4l2sink device=/dev/video10`:

1.  ✅  __Firefox__ 134.0.2, __Chromium__ 132.0.6834.110: WebRTC (NOTE: __Chromium__ requires `exclusive_caps=1`) - served [this page](https://github.com/user-attachments/files/18635159/index.html.zip) via __nginx__ on localhost.
    
2.  ✅ __Discord__ stable 364202 (37108ad): Needs `exclusive_caps` on.
3.  ✅  __Signal__ 7.40.0: Needs `exclusive_caps` on and feed with compatible pixel format e.g. YUYV 4:2:2 (YUY2):
    ```
    gst-launch-1.0 videotestsrc ! "video/x-raw,height=480,width=480,format=YUY2" ! v4l2sink device=/dev/video10
    ```
    
4.  ✅ __OBS__ 30.2.2 - V4L2 input: Needs compatible pixel format e.g. YUYV 4:2:2 (YUY2):
    ```
    gst-launch-1.0 videotestsrc ! "video/x-raw,height=240,width=320,format=YUY2" ! v4l2sink device=/dev/video10
    ```
    
5.   ❌ __OBS__ 30.2.2 - Virtual camera: __OBS__ uses a _very_ non-V4L2-UAPI kludge - will prepare a PR for __OBS__ to fix (started discussion [here](https://github.com/umlaeute/v4l2loopback/discussions/615))
