### PR TITLE
ioctl to query the module version

### DIFF
--- a/utils/v4l2loopback-ctl.c
+++ b/utils/v4l2loopback-ctl.c
@@ -1551,7 +1551,19 @@ int main(int argc, char **argv)
 			if (len > 0) {
 				if (len < sizeof(buf))
 					buf[len] = 0;
-				printf("v4l2loopback module v%s", buf);
+				printf("v4l2loopback sysfs v%s", buf);
+			}
+			close(fd);
+		}
+		fd = open_controldevice();
+		if (fd >= 0) {
+			__u32 version = 0;
+			if (ioctl(fd, V4L2LOOPBACK_CTL_VERSION, &version) ==
+			    0) {
+				printf("v4l2loopback module v%d.%d.%d\n",
+				       (version >> 16) & 0xff,
+				       (version >> 8) & 0xff,
+				       (version >> 0) & 0xff);
 			}
 		}
 		break;

--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -33,6 +33,10 @@
 #include <linux/miscdevice.h>
 #include "v4l2loopback.h"
 
+#define V4L2LOOPBACK_CTL_ADD_legacy 0x4C80
+#define V4L2LOOPBACK_CTL_REMOVE_legacy 0x4C81
+#define V4L2LOOPBACK_CTL_QUERY_legacy 0x4C82
+
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 0, 0)
 #error This module is not supported on kernels before 4.0.0.
 #endif
@@ -2985,6 +2989,7 @@ static long v4l2loopback_control_ioctl(struct file *file, unsigned int cmd,
 		break;
 		/* add a v4l2loopback device (pair), based on the user-provided specs */
 	case V4L2LOOPBACK_CTL_ADD:
+	case V4L2LOOPBACK_CTL_ADD_legacy:
 		if (parm) {
 			if ((ret = copy_from_user(&conf, (void *)parm,
 						  sizeof(conf))) < 0)
@@ -2997,6 +3002,7 @@ static long v4l2loopback_control_ioctl(struct file *file, unsigned int cmd,
 		break;
 		/* remove a v4l2loopback device (both capture and output) */
 	case V4L2LOOPBACK_CTL_REMOVE:
+	case V4L2LOOPBACK_CTL_REMOVE_legacy:
 		ret = v4l2loopback_lookup((int)parm, &dev);
 		if (ret >= 0 && dev) {
 			ret = -EBUSY;
@@ -3010,6 +3016,7 @@ static long v4l2loopback_control_ioctl(struct file *file, unsigned int cmd,
 		 * this is mostly about limits (which cannot be queried directly with  VIDIOC_G_FMT and friends
 		 */
 	case V4L2LOOPBACK_CTL_QUERY:
+	case V4L2LOOPBACK_CTL_QUERY_legacy:
 		if (!parm)
 			break;
 		if ((ret = copy_from_user(&conf, (void *)parm, sizeof(conf))) <

--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -2972,6 +2972,7 @@ static long v4l2loopback_control_ioctl(struct file *file, unsigned int cmd,
 	struct v4l2_loopback_config *confptr = &conf;
 	int device_nr, capture_nr, output_nr;
 	int ret;
+	const __u32 version = V4L2LOOPBACK_VERSION_CODE;
 
 	ret = mutex_lock_killable(&v4l2loopback_ctl_mutex);
 	if (ret)
@@ -3056,6 +3057,15 @@ static long v4l2loopback_control_ioctl(struct file *file, unsigned int cmd,
 		conf.debug = debug;
 		MARK();
 		if (copy_to_user((void *)parm, &conf, sizeof(conf))) {
+			ret = -EFAULT;
+			break;
+		}
+		ret = 0;
+		break;
+	case V4L2LOOPBACK_CTL_VERSION:
+		if (!parm)
+			break;
+		if (copy_to_user((void *)parm, &version, sizeof(version))) {
 			ret = -EFAULT;
 			break;
 		}

--- a/v4l2loopback.h
+++ b/v4l2loopback.h
@@ -77,6 +77,14 @@ struct v4l2_loopback_config {
 	int announce_all_caps;
 };
 
+#define V4L2LOOPBACK_CTL_IOCTLMAGIC '~'
+
+/* a pointer to an (unsigned int) that - on success - will hold
+ * the version code of the v4l2loopback module
+ * as returned by KERNEL_VERSION(MAJOR, MINOR, BUGFIX)
+ */
+#define V4L2LOOPBACK_CTL_VERSION _IOR(V4L2LOOPBACK_CTL_IOCTLMAGIC, 0, __u32)
+
 /* a pointer to a (struct v4l2_loopback_config) that has all values you wish to impose on the
  * to-be-created device set.
  * if the ptr is NULL, a new device is created with default values at the driver's discretion.

--- a/v4l2loopback.h
+++ b/v4l2loopback.h
@@ -86,13 +86,13 @@ struct v4l2_loopback_config {
  */
 #define V4L2LOOPBACK_CTL_ADD 0x4C80
 
+/* the device-number (either CAPTURE or OUTPUT) associated with the loopback-device */
+#define V4L2LOOPBACK_CTL_REMOVE 0x4C81
+
 /* a pointer to a (struct v4l2_loopback_config) that has output_nr and/or capture_nr set
  * (the two values must either refer to video-devices associated with the same loopback device
  *  or exactly one of them must be <0
  */
 #define V4L2LOOPBACK_CTL_QUERY 0x4C82
-
-/* the device-number (either CAPTURE or OUTPUT) associated with the loopback-device */
-#define V4L2LOOPBACK_CTL_REMOVE 0x4C81
 
 #endif /* _V4L2LOOPBACK_H */

--- a/v4l2loopback.h
+++ b/v4l2loopback.h
@@ -92,15 +92,17 @@ struct v4l2_loopback_config {
  * returns the device_nr of the OUTPUT device (which can be used with V4L2LOOPBACK_CTL_QUERY,
  * to get more information on the device)
  */
-#define V4L2LOOPBACK_CTL_ADD 0x4C80
+#define V4L2LOOPBACK_CTL_ADD \
+	_IOW(V4L2LOOPBACK_CTL_IOCTLMAGIC, 1, struct v4l2_loopback_config)
 
 /* the device-number (either CAPTURE or OUTPUT) associated with the loopback-device */
-#define V4L2LOOPBACK_CTL_REMOVE 0x4C81
+#define V4L2LOOPBACK_CTL_REMOVE _IOW(V4L2LOOPBACK_CTL_IOCTLMAGIC, 2, int)
 
 /* a pointer to a (struct v4l2_loopback_config) that has output_nr and/or capture_nr set
  * (the two values must either refer to video-devices associated with the same loopback device
  *  or exactly one of them must be <0
  */
-#define V4L2LOOPBACK_CTL_QUERY 0x4C82
+#define V4L2LOOPBACK_CTL_QUERY \
+	_IOWR(V4L2LOOPBACK_CTL_IOCTLMAGIC, 3, struct v4l2_loopback_config)
 
 #endif /* _V4L2LOOPBACK_H */


### PR DESCRIPTION
This is a follow up on https://github.com/v4l2loopback/v4l2loopback/discussions/617

afaui https://github.com/obsproject/obs-studio/pull/11906, my suggestion to use *sysfs* (`/sys/module/v4l2loopback/version`) to query the version won't play nicely with flatpak (which only grants access to `/dev/`)

so here's a brand-new ioctl `V4L2LOOPBACK_CTL_VERSION` that allows us to query the `V4L2LOOPBACK_VERSION_CODE` from the `/dev/v4l2loopback` device.

while there, I've also cleaned up the other ioctl's, to use `_IOW` and `_IOWR` rather than inventing our own ioctl numbers.
i think this should have been done like this from the beginning...

of course this is a breaking change!
the module itself has code in place so it keeps working with the legacy ioctl's (so applications built against the old `v4l2loopback.h` will continue to work with both older and new versions of the ioctls), but the public API now only has the new numbers (so applications built against the new `v4l2loopback.h` will not work with older versions of the module).

@stephematician i think this is an acceptable tradeoff, but i would like to have a second opinion.