### PR TITLE
Create a badge with all kernels tested in the CI

### DIFF
--- a/.github/workflows/kmod-compatibility-checks.yml
+++ b/.github/workflows/kmod-compatibility-checks.yml
@@ -121,6 +121,7 @@ jobs:
 
   make_badges:
     if: always()
+    needs: kmod-compile
     runs-on: ubuntu-latest
     steps:
       - name: get artifacts

--- a/.github/workflows/kmod-compatibility-checks.yml
+++ b/.github/workflows/kmod-compatibility-checks.yml
@@ -97,13 +97,13 @@ jobs:
           osrelease="$(lsb_release -sc)"
           rm -rf "${statefile}"
           for k in ${succeeded}; do
-            echo "success ${osname} ${osversion} ${osrelease} ${k}"
+            echo "${osname} ${osversion} ${osrelease} ${k} success"
           done >> "${statefile}"
           for k in ${skipped}; do
-            echo "skip    ${osname} ${osversion} ${osrelease} ${k}"
+            echo "${osname} ${osversion} ${osrelease} ${k} skip"
           done >> "${statefile}"
           for k in ${failed}; do
-            echo "failure ${osname} ${osrelease} ${k}"
+            echo "${osname} ${osrelease} ${k} failure"
           done >> "${statefile}"
           echo "#### Successful builds for kernels: ${succeeded}";
           if [ "x${skipped}" != "x" ]; then
@@ -130,13 +130,12 @@ jobs:
       - name: create badge
         shell: bash
         run: |
-          find */ -type f -name "buildstate.txt" -exec grep -h . {} + | while read state os version codename kernel; do
-            echo "${os} ${version} ${codename} ${kernel} ${state}"
-          done | sed -e 's|success$|#4C1|' -e 's|skip$|#D3D3D3|' -e 's|failure|#E05D44' > allstates.txt
+          find */ -type f -name "buildstate.txt" -exec grep -h . {} + | sort -u > allstates.txt
           numtests=$(grep -c . allstates.txt)
-          echo '<?xml version="1.0" encoding="UTF-8"?> <svg xmlns="http://www.w3.org/2000/svg" width="323" height="@height@"> <g fill="#fff" text-anchor="left" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11"> <linearGradient id="b" x2="0" y2="100%"> <stop offset="0" stop-color="#bbb" stop-opacity=".1"/> <stop offset="1" stop-opacity=".1"/> </linearGradient>' | sed -e "s|@height@|$((numtests * 22))|g" > badge.svg
-          cat -n "$1" | while read num os version kernel color; do
-            echo '<g transform="translate(0 @dy@)" mask="url(#anybadge_1)"> <path fill="#555" d="M0 0h148v20H0z"/> <path fill="@color@" d="M148 0h175v20H148z"/> <path fill="url(#b)" d="M0 0h323v20H0z"/> <text x="9.0" y="15" fill="#010101" fill-opacity=".3">@os@/@version@</text> <text x="8.0" y="14">@os@/@version@</text> <text x="156.5" y="15" fill="#010101" fill-opacity=".3">@kernel@</text> <text x="155.5" y="14">@kernel@</text> </g>' | sed -e "s|@dy@|$((22*(num-1)))|g" -e "s|@color@|${color}|g" -e "s|@os@|${os}|g" -e "s|@version@|${version}|g" -e "s|@kernel@|${kernel}|g"
+          echo '<?xml version="1.0" encoding="UTF-8"?> <svg xmlns="http://www.w3.org/2000/svg" width="323" height="@height@">" > badge.svg
+          echo "<style>.success {fill:#4C1} .skip {fill:#D3D3D3} .failure {fill:#E05D44}</style> <g fill="#fff" text-anchor="left" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11"> <linearGradient id="b" x2="0" y2="100%"> <stop offset="0" stop-color="#bbb" stop-opacity=".1"/> <stop offset="1" stop-opacity=".1"/> </linearGradient>' | sed -e "s|@height@|$((numtests * 22))|g" > badge.svg
+          cat -n allstates.txt | while read num os _ version kernel state; do
+            echo '<g transform="translate(0 @dy@)" mask="url(#anybadge_1)"> <path fill="#555" d="M0 0h148v20H0z"/> <path class="@state@" d="M148 0h175v20H148z"/> <path fill="url(#b)" d="M0 0h323v20H0z"/> <text x="9.0" y="15" fill="#010101" fill-opacity=".3">@os@/@version@</text> <text x="8.0" y="14">@os@/@version@</text> <text x="156.5" y="15" fill="#010101" fill-opacity=".3">@kernel@</text> <text x="155.5" y="14">@kernel@</text> </g>' | sed -e "s|@dy@|$((22*(num-1)))|g" -e "s|@state@|${state}|g" -e "s|@os@|${os}|g" -e "s|@version@|${version}|g" -e "s|@kernel@|${kernel}|g"
           done >> badge.svg
           echo '</g> </svg>' >> badge.svg
           cat badge.svg

--- a/.github/workflows/kmod-compatibility-checks.yml
+++ b/.github/workflows/kmod-compatibility-checks.yml
@@ -53,7 +53,7 @@ jobs:
           apt-get update --quiet;
           apt-get install --yes --no-install-recommends kmod
           apt-get install --yes --no-install-recommends dkms || true
-          apt-get install --yes --no-install-recommends dctrl-tools || true
+          apt-get install --yes --no-install-recommends lsb-release dctrl-tools || true
           apt-get install --yes --no-install-recommends linux-headers-generic linux-headers || true
           grep-aptavail -n -s Package  -F Provides -X linux-headers -o -F Provides -X linux-headers-generic \
                 | xargs apt-get install --yes --no-install-recommends || true
@@ -92,15 +92,17 @@ jobs:
             make KERNELRELEASE="${kver}" clean || test ${ret} -ne 0
           done
           statefile=${{ matrix.series }}.state
+          osname="$(lsb_release -si)"
+          osrelease="$(lsb_release -sc)"
           rm -rf "${statefile}"
           for k in ${succeeded}; do
-            echo "success ${k}"
+            echo "success ${osname} ${osrelease} ${k}"
           done >> "${statefile}"
           for k in ${skipped}; do
-            echo "skip    ${k}"
+            echo "skip    ${osname} ${osrelease} ${k}"
           done >> "${statefile}"
           for k in ${failed}; do
-            echo "failure ${k}"
+            echo "failure ${osname} ${osrelease} ${k}"
           done >> "${statefile}"
           echo "#### Successful builds for kernels: ${succeeded}";
           if [ "x${skipped}" != "x" ]; then

--- a/.github/workflows/kmod-compatibility-checks.yml
+++ b/.github/workflows/kmod-compatibility-checks.yml
@@ -146,3 +146,4 @@ jobs:
           gist_id: f877d3367ab47ffd2d203b1062c41825
           file_path: badge.svg
           file_type: text
+        if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'

--- a/.github/workflows/kmod-compatibility-checks.yml
+++ b/.github/workflows/kmod-compatibility-checks.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - develop
       - main
+      - badges
 
 jobs:
   get_debuntu_releases:

--- a/.github/workflows/kmod-compatibility-checks.yml
+++ b/.github/workflows/kmod-compatibility-checks.yml
@@ -91,11 +91,11 @@ jobs:
             fi;
             make KERNELRELEASE="${kver}" clean || test ${ret} -ne 0
           done
+          echo "#### Successful builds for kernels: ${succeeded}";
+          if [ "x${skipped}" != "x" ]; then
+            echo "#### Skipped kernels: ${skipped}";
+          fi
           if [ "x${failed}" != "x" ]; then
             echo "#### Failed kernels: ${failed}";
             exit 1
           fi
-          if [ "x${skipped}" != "x" ]; then
-            echo "#### Skipped kernels: ${skipped}";
-          fi
-          echo "#### Successful builds for kernels: ${succeeded}";

--- a/.github/workflows/kmod-compatibility-checks.yml
+++ b/.github/workflows/kmod-compatibility-checks.yml
@@ -132,8 +132,9 @@ jobs:
         run: |
           find */ -type f -name "buildstate.txt" -exec grep -h . {} + | sort -u > allstates.txt
           numtests=$(grep -c . allstates.txt)
-          echo '<?xml version="1.0" encoding="UTF-8"?> <svg xmlns="http://www.w3.org/2000/svg" width="323" height="@height@">' > badge.svg
-          echo '<style>.success {fill:#4C1} .skip {fill:#D3D3D3} .failure {fill:#E05D44}</style> <g fill="#fff" text-anchor="left" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11"> <linearGradient id="b" x2="0" y2="100%"> <stop offset="0" stop-color="#bbb" stop-opacity=".1"/> <stop offset="1" stop-opacity=".1"/> </linearGradient>' | sed -e "s|@height@|$((numtests * 22))|g" > badge.svg
+          echo -n > badge.svg
+          echo '<?xml version="1.0" encoding="UTF-8"?> <svg xmlns="http://www.w3.org/2000/svg" width="323" height="@height@">' >> badge.svg
+          echo '<style>.success {fill:#4C1} .skip {fill:#D3D3D3} .failure {fill:#E05D44}</style> <g fill="#fff" text-anchor="left" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11"> <linearGradient id="b" x2="0" y2="100%"> <stop offset="0" stop-color="#bbb" stop-opacity=".1"/> <stop offset="1" stop-opacity=".1"/> </linearGradient>' | sed -e "s|@height@|$((numtests * 22))|g" >> badge.svg
           cat -n allstates.txt | while read num os _ version kernel state; do
             echo '<g transform="translate(0 @dy@)" mask="url(#anybadge_1)"> <path fill="#555" d="M0 0h148v20H0z"/> <path class="@state@" d="M148 0h175v20H148z"/> <path fill="url(#b)" d="M0 0h323v20H0z"/> <text x="9.0" y="15" fill="#010101" fill-opacity=".3">@os@/@version@</text> <text x="8.0" y="14">@os@/@version@</text> <text x="156.5" y="15" fill="#010101" fill-opacity=".3">@kernel@</text> <text x="155.5" y="14">@kernel@</text> </g>' | sed -e "s|@dy@|$((22*(num-1)))|g" -e "s|@state@|${state}|g" -e "s|@os@|${os}|g" -e "s|@version@|${version}|g" -e "s|@kernel@|${kernel}|g"
           done >> badge.svg

--- a/.github/workflows/kmod-compatibility-checks.yml
+++ b/.github/workflows/kmod-compatibility-checks.yml
@@ -132,8 +132,8 @@ jobs:
         run: |
           find */ -type f -name "buildstate.txt" -exec grep -h . {} + | sort -u > allstates.txt
           numtests=$(grep -c . allstates.txt)
-          echo '<?xml version="1.0" encoding="UTF-8"?> <svg xmlns="http://www.w3.org/2000/svg" width="323" height="@height@">" > badge.svg
-          echo "<style>.success {fill:#4C1} .skip {fill:#D3D3D3} .failure {fill:#E05D44}</style> <g fill="#fff" text-anchor="left" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11"> <linearGradient id="b" x2="0" y2="100%"> <stop offset="0" stop-color="#bbb" stop-opacity=".1"/> <stop offset="1" stop-opacity=".1"/> </linearGradient>' | sed -e "s|@height@|$((numtests * 22))|g" > badge.svg
+          echo '<?xml version="1.0" encoding="UTF-8"?> <svg xmlns="http://www.w3.org/2000/svg" width="323" height="@height@">' > badge.svg
+          echo '<style>.success {fill:#4C1} .skip {fill:#D3D3D3} .failure {fill:#E05D44}</style> <g fill="#fff" text-anchor="left" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11"> <linearGradient id="b" x2="0" y2="100%"> <stop offset="0" stop-color="#bbb" stop-opacity=".1"/> <stop offset="1" stop-opacity=".1"/> </linearGradient>' | sed -e "s|@height@|$((numtests * 22))|g" > badge.svg
           cat -n allstates.txt | while read num os _ version kernel state; do
             echo '<g transform="translate(0 @dy@)" mask="url(#anybadge_1)"> <path fill="#555" d="M0 0h148v20H0z"/> <path class="@state@" d="M148 0h175v20H148z"/> <path fill="url(#b)" d="M0 0h323v20H0z"/> <text x="9.0" y="15" fill="#010101" fill-opacity=".3">@os@/@version@</text> <text x="8.0" y="14">@os@/@version@</text> <text x="156.5" y="15" fill="#010101" fill-opacity=".3">@kernel@</text> <text x="155.5" y="14">@kernel@</text> </g>' | sed -e "s|@dy@|$((22*(num-1)))|g" -e "s|@state@|${state}|g" -e "s|@os@|${os}|g" -e "s|@version@|${version}|g" -e "s|@kernel@|${kernel}|g"
           done >> badge.svg

--- a/.github/workflows/kmod-compatibility-checks.yml
+++ b/.github/workflows/kmod-compatibility-checks.yml
@@ -125,10 +125,25 @@ jobs:
     needs: kmod-compile
     runs-on: ubuntu-latest
     steps:
-      - name: get artifacts
+      - name: get status artifacts
         uses: actions/download-artifact@v4
-      - name: show data
+      - name: create badge
         shell: bash
         run: |
-          find .
-          find . -type f -name "buildstate.txt" -exec grep . {} +
+          find */ -type f -name "buildstate.txt" -exec grep -h . {} + | while read state os version codename kernel; do
+            echo "${os} ${version} ${codename} ${kernel} ${state}"
+          done | sed -e 's|success$|#4C1|' -e 's|skip$|#D3D3D3|' -e 's|failure|#E05D44' > allstates.txt
+          numtests=$(grep -c . allstates.txt)
+          echo '<?xml version="1.0" encoding="UTF-8"?> <svg xmlns="http://www.w3.org/2000/svg" width="323" height="@height@"> <g fill="#fff" text-anchor="left" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11"> <linearGradient id="b" x2="0" y2="100%"> <stop offset="0" stop-color="#bbb" stop-opacity=".1"/> <stop offset="1" stop-opacity=".1"/> </linearGradient>' | sed -e "s|@height@|$((numtests * 22))|g" > badge.svg
+          cat -n "$1" | while read num os version kernel color; do
+            echo '<g transform="translate(0 @dy@)" mask="url(#anybadge_1)"> <path fill="#555" d="M0 0h148v20H0z"/> <path fill="@color@" d="M148 0h175v20H148z"/> <path fill="url(#b)" d="M0 0h323v20H0z"/> <text x="9.0" y="15" fill="#010101" fill-opacity=".3">@os@/@version@</text> <text x="8.0" y="14">@os@/@version@</text> <text x="156.5" y="15" fill="#010101" fill-opacity=".3">@kernel@</text> <text x="155.5" y="14">@kernel@</text> </g>' | sed -e "s|@dy@|$((22*(num-1)))|g" -e "s|@color@|${color}|g" -e "s|@os@|${os}|g" -e "s|@version@|${version}|g" -e "s|@kernel@|${kernel}|g"
+          done >> badge.svg
+          echo '</g> </svg>' >> badge.svg
+          cat badge.svg
+      - name: deploy badge
+        uses: exuanbo/actions-deploy-gist@v1
+        with:
+          token: ${{ secrets.GIST_SECRET }}
+          gist_id: f877d3367ab47ffd2d203b1062c41825
+          file_path: badge.svg
+          file_type: text

--- a/.github/workflows/kmod-compatibility-checks.yml
+++ b/.github/workflows/kmod-compatibility-checks.yml
@@ -133,10 +133,10 @@ jobs:
           find */ -type f -name "buildstate.txt" -exec grep -h . {} + | sort -u > allstates.txt
           numtests=$(grep -c . allstates.txt)
           echo -n > badge.svg
-          echo '<?xml version="1.0" encoding="UTF-8"?> <svg xmlns="http://www.w3.org/2000/svg" width="323" height="@height@">' >> badge.svg
+          echo '<?xml version="1.0" encoding="UTF-8"?> <svg xmlns="http://www.w3.org/2000/svg" width="333" height="@height@">' | sed -e "s|@height@|$((numtests*22))|g">> badge.svg
           echo '<style>.success {fill:#4C1} .skip {fill:#D3D3D3} .failure {fill:#E05D44}</style> <g fill="#fff" text-anchor="left" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11"> <linearGradient id="b" x2="0" y2="100%"> <stop offset="0" stop-color="#bbb" stop-opacity=".1"/> <stop offset="1" stop-opacity=".1"/> </linearGradient>' | sed -e "s|@height@|$((numtests * 22))|g" >> badge.svg
           cat -n allstates.txt | while read num os _ version kernel state; do
-            echo '<g transform="translate(0 @dy@)" mask="url(#anybadge_1)"> <path fill="#555" d="M0 0h148v20H0z"/> <path class="@state@" d="M148 0h175v20H148z"/> <path fill="url(#b)" d="M0 0h323v20H0z"/> <text x="9.0" y="15" fill="#010101" fill-opacity=".3">@os@/@version@</text> <text x="8.0" y="14">@os@/@version@</text> <text x="156.5" y="15" fill="#010101" fill-opacity=".3">@kernel@</text> <text x="155.5" y="14">@kernel@</text> </g>' | sed -e "s|@dy@|$((22*(num-1)))|g" -e "s|@state@|${state}|g" -e "s|@os@|${os}|g" -e "s|@version@|${version}|g" -e "s|@kernel@|${kernel}|g"
+            echo '<g transform="translate(0 @dy@)" mask="url(#anybadge_1)"> <path fill="#555" d="M0 0h148v20H0z"/> <path class="@state@" d="M148 0h185v20H148z"/> <path fill="url(#b)" d="M0 0h333v20H0z"/> <text x="9.0" y="15" fill="#010101" fill-opacity=".3">@os@/@version@</text> <text x="8.0" y="14">@os@/@version@</text> <text x="156.5" y="15" fill="#010101" fill-opacity=".3">@kernel@</text> <text x="155.5" y="14">@kernel@</text> </g>' | sed -e "s|@dy@|$((22*(num-1)))|g" -e "s|@state@|${state}|g" -e "s|@os@|${os}|g" -e "s|@version@|${version}|g" -e "s|@kernel@|${kernel}|g"
           done >> badge.svg
           echo '</g> </svg>' >> badge.svg
           cat badge.svg

--- a/.github/workflows/kmod-compatibility-checks.yml
+++ b/.github/workflows/kmod-compatibility-checks.yml
@@ -117,8 +117,8 @@ jobs:
         if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.series }}.state
-          path: ${{ matrix.series }}.state
+          name: ${{ matrix.series }}
+          path: buildstate.txt
 
   make_badges:
     if: always()
@@ -131,4 +131,4 @@ jobs:
         shell: bash
         run: |
           find .
-          find . -name "*.state" -exec grep . {} +
+          find . -type f -name "buildstate.txt" -exec grep . {} +

--- a/.github/workflows/kmod-compatibility-checks.yml
+++ b/.github/workflows/kmod-compatibility-checks.yml
@@ -91,15 +91,16 @@ jobs:
             fi;
             make KERNELRELEASE="${kver}" clean || test ${ret} -ne 0
           done
-          statefile=${{ matrix.series }}.state
+          statefile=buildstate.txt
           osname="$(lsb_release -si)"
+          osversion="$(lsb_release -sr)"
           osrelease="$(lsb_release -sc)"
           rm -rf "${statefile}"
           for k in ${succeeded}; do
-            echo "success ${osname} ${osrelease} ${k}"
+            echo "success ${osname} ${osversion} ${osrelease} ${k}"
           done >> "${statefile}"
           for k in ${skipped}; do
-            echo "skip    ${osname} ${osrelease} ${k}"
+            echo "skip    ${osname} ${osversion} ${osrelease} ${k}"
           done >> "${statefile}"
           for k in ${failed}; do
             echo "failure ${osname} ${osrelease} ${k}"

--- a/.github/workflows/kmod-compatibility-checks.yml
+++ b/.github/workflows/kmod-compatibility-checks.yml
@@ -118,3 +118,15 @@ jobs:
         with:
           name: ${{ matrix.series }}.state
           path: ${{ matrix.series }}.state
+
+  make_badges:
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: get artifacts
+        uses: actions/download-artifact@v4
+      - name: show data
+        shell: bash
+        run: |
+          find .
+          find . -name "*.state" -exec grep . {} +

--- a/.github/workflows/kmod-compatibility-checks.yml
+++ b/.github/workflows/kmod-compatibility-checks.yml
@@ -91,6 +91,17 @@ jobs:
             fi;
             make KERNELRELEASE="${kver}" clean || test ${ret} -ne 0
           done
+          statefile=${{ matrix.series }}.state
+          rm -rf "${statefile}"
+          for k in ${succeeded}; do
+            echo "success ${k}"
+          done >> "${statefile}"
+          for k in ${skipped}; do
+            echo "skip    ${k}"
+          done >> "${statefile}"
+          for k in ${failed}; do
+            echo "failure ${k}"
+          done >> "${statefile}"
           echo "#### Successful builds for kernels: ${succeeded}";
           if [ "x${skipped}" != "x" ]; then
             echo "#### Skipped kernels: ${skipped}";
@@ -99,3 +110,9 @@ jobs:
             echo "#### Failed kernels: ${failed}";
             exit 1
           fi
+      - name: Publish state
+        if: success() || failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.series }}.state
+          path: ${{ matrix.series }}.state

--- a/.github/workflows/kmod-compatibility-checks.yml
+++ b/.github/workflows/kmod-compatibility-checks.yml
@@ -9,7 +9,6 @@ on:
     branches:
       - develop
       - main
-      - badges
 
 jobs:
   get_debuntu_releases:


### PR DESCRIPTION
Inspired by https://github.com/v4l2loopback/v4l2loopback/issues/380, this PR creates a badge from the performed tests.

It's currently viewable on the [wiki](https://github.com/v4l2loopback/v4l2loopback/wiki/Build-State), and looks like this:

![v4l2loopback builds with multiple kernels](https://gist.githubusercontent.com/umlaeute/f877d3367ab47ffd2d203b1062c41825/raw/94698326f49fded12896e94e687cbd8a4181ba1f/badge.svg)