### PR TITLE
Drop from_timer macro usage

### DIFF
--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -45,7 +45,7 @@
 #define strscpy strlcpy
 #endif
 
-#if defined(timer_setup) && defined(from_timer)
+#if defined(timer_setup)
 #define HAVE_TIMER_SETUP
 #endif
 
@@ -2669,7 +2669,8 @@ static void check_timers(struct v4l2_loopback_device *dev)
 #ifdef HAVE_TIMER_SETUP
 static void sustain_timer_clb(struct timer_list *t)
 {
-	struct v4l2_loopback_device *dev = from_timer(dev, t, sustain_timer);
+	struct v4l2_loopback_device *dev =
+		container_of(t, struct v4l2_loopback_device, sustain_timer);
 #else
 static void sustain_timer_clb(unsigned long nr)
 {
@@ -2694,7 +2695,8 @@ static void sustain_timer_clb(unsigned long nr)
 #ifdef HAVE_TIMER_SETUP
 static void timeout_timer_clb(struct timer_list *t)
 {
-	struct v4l2_loopback_device *dev = from_timer(dev, t, timeout_timer);
+	struct v4l2_loopback_device *dev =
+		container_of(t, struct v4l2_loopback_device, timeout_timer);
 #else
 static void timeout_timer_clb(unsigned long nr)
 {


### PR DESCRIPTION
The from_timer() macro is dropped for v6.16-rc1, just use container_of() just like the from_timer() macro does.