### PR TITLE
Add dma-buf support (VIDIOC_EXPBUF and DMABUF import on the OUTPUT queue)

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,3 +1,3 @@
-all: test_dqbuf consumer producer
+all: test_dqbuf test_dmabuf consumer producer
 
 consumer producer: common.h

--- a/tests/test_dmabuf.c
+++ b/tests/test_dmabuf.c
@@ -1,0 +1,165 @@
+/*
+ * test_dmabuf.c -- v4l2loopback DMABUF self-test
+ *
+ * Exercises VIDIOC_EXPBUF and V4L2_MEMORY_DMABUF on the OUTPUT queue in a
+ * single process:
+ *   - fill an MMAP OUTPUT buffer, export it with VIDIOC_EXPBUF, and check the
+ *     exported dma-buf maps the same pixels
+ *   - check EXPBUF rejects unsupported flags
+ *   - re-request the queue as V4L2_MEMORY_DMABUF, queue the exported fd back
+ *     in, and check QBUF/DQBUF preserve the DMABUF memory type
+ *   - check VIDIOC_EXPBUF on an imported slot returns a pass-through fd
+ *
+ * Run against a loopback node, e.g. ./test_dmabuf /dev/video10
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/videodev2.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#define WIDTH 320
+#define HEIGHT 240
+#define PATTERN 0xDEADBEEFu
+
+static int fails;
+
+#define OK(cond, msg)                                            \
+	do {                                                     \
+		if (cond) {                                      \
+			printf("ok   - %s\n", (msg));            \
+		} else {                                         \
+			printf("FAIL - %s: %s\n", (msg),         \
+			       strerror(errno));                 \
+			fails++;                                 \
+		}                                                \
+	} while (0)
+
+int main(int argc, char **argv)
+{
+	enum v4l2_buf_type otype = V4L2_BUF_TYPE_VIDEO_OUTPUT;
+	struct v4l2_format fmt = { 0 };
+	struct v4l2_requestbuffers req = { 0 };
+	struct v4l2_buffer buf = { 0 };
+	struct v4l2_exportbuffer eb = { 0 };
+	void *vmap = MAP_FAILED, *dmap = MAP_FAILED;
+	size_t length;
+	unsigned int i;
+	int fd, dfd = -1;
+
+	if (argc < 2) {
+		printf("usage: %s <videodevice>\n", argv[0]);
+		return 2;
+	}
+
+	fd = open(argv[1], O_RDWR);
+	if (fd < 0) {
+		perror("open");
+		return 2;
+	}
+
+	/* 1. configure the OUTPUT queue as MMAP and fill buffer 0 */
+	fmt.type = otype;
+	fmt.fmt.pix.width = WIDTH;
+	fmt.fmt.pix.height = HEIGHT;
+	fmt.fmt.pix.pixelformat = V4L2_PIX_FMT_RGB32;
+	OK(ioctl(fd, VIDIOC_S_FMT, &fmt) == 0, "S_FMT");
+
+	req.count = 2;
+	req.type = otype;
+	req.memory = V4L2_MEMORY_MMAP;
+	OK(ioctl(fd, VIDIOC_REQBUFS, &req) == 0, "REQBUFS(MMAP)");
+
+	buf.type = otype;
+	buf.memory = V4L2_MEMORY_MMAP;
+	buf.index = 0;
+	OK(ioctl(fd, VIDIOC_QUERYBUF, &buf) == 0, "QUERYBUF");
+	length = buf.length;
+
+	vmap = mmap(NULL, length, PROT_READ | PROT_WRITE, MAP_SHARED, fd,
+		    buf.m.offset);
+	OK(vmap != MAP_FAILED, "mmap output buffer");
+	if (vmap != MAP_FAILED)
+		for (i = 0; i < length / 4; i++)
+			((uint32_t *)vmap)[i] = PATTERN;
+
+	/* 2. export buffer 0 and check the dma-buf maps the same pixels */
+	eb.type = otype;
+	eb.index = 0;
+	eb.flags = O_CLOEXEC | O_RDWR;
+	OK(ioctl(fd, VIDIOC_EXPBUF, &eb) == 0 && eb.fd >= 0,
+	   "EXPBUF (MMAP-backed export)");
+	dfd = eb.fd;
+
+	if (dfd >= 0) {
+		dmap = mmap(NULL, length, PROT_READ, MAP_SHARED, dfd, 0);
+		OK(dmap != MAP_FAILED, "mmap exported dma-buf");
+	}
+	OK(dmap != MAP_FAILED && ((uint32_t *)dmap)[0] == PATTERN &&
+		   ((uint32_t *)dmap)[length / 4 - 1] == PATTERN,
+	   "exported dma-buf sees the written pixels");
+
+	/* unsupported flags must be rejected */
+	{
+		struct v4l2_exportbuffer bad = { .type = otype,
+						 .index = 0,
+						 .flags = O_APPEND };
+		OK(ioctl(fd, VIDIOC_EXPBUF, &bad) < 0 && errno == EINVAL,
+		   "EXPBUF rejects unsupported flags");
+	}
+
+	if (dmap != MAP_FAILED)
+		munmap(dmap, length);
+	if (vmap != MAP_FAILED)
+		munmap(vmap, length); /* unmap so REQBUFS can reconfigure */
+
+	/* 3. reconfigure as DMABUF and queue the exported fd back in */
+	memset(&req, 0, sizeof(req));
+	req.count = 2;
+	req.type = otype;
+	req.memory = V4L2_MEMORY_DMABUF;
+	OK(ioctl(fd, VIDIOC_REQBUFS, &req) == 0, "REQBUFS(DMABUF)");
+
+	memset(&buf, 0, sizeof(buf));
+	buf.type = otype;
+	buf.memory = V4L2_MEMORY_DMABUF;
+	buf.index = 0;
+	buf.m.fd = dfd;
+	OK(ioctl(fd, VIDIOC_QBUF, &buf) == 0, "QBUF(DMABUF)");
+	OK(buf.memory == V4L2_MEMORY_DMABUF,
+	   "QBUF preserves DMABUF memory type");
+
+	/* 4. EXPBUF on the imported slot returns a pass-through fd */
+	memset(&eb, 0, sizeof(eb));
+	eb.type = otype;
+	eb.index = 0;
+	eb.flags = O_CLOEXEC;
+	OK(ioctl(fd, VIDIOC_EXPBUF, &eb) == 0 && eb.fd >= 0,
+	   "EXPBUF pass-through on imported slot");
+	if (eb.fd >= 0)
+		close(eb.fd);
+
+	OK(ioctl(fd, VIDIOC_STREAMON, &otype) == 0, "STREAMON");
+
+	memset(&buf, 0, sizeof(buf));
+	buf.type = otype;
+	buf.memory = V4L2_MEMORY_DMABUF;
+	OK(ioctl(fd, VIDIOC_DQBUF, &buf) == 0, "DQBUF(DMABUF)");
+	OK(buf.memory == V4L2_MEMORY_DMABUF,
+	   "DQBUF preserves DMABUF memory type");
+
+	ioctl(fd, VIDIOC_STREAMOFF, &otype);
+	if (dfd >= 0)
+		close(dfd);
+	close(fd);
+
+	printf("\n%s (%d failure%s)\n", fails ? "FAILED" : "PASSED", fails,
+	       fails == 1 ? "" : "s");
+	return fails ? 1 : 0;
+}

--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -16,6 +16,9 @@
 #include <linux/version.h>
 #include <linux/vmalloc.h>
 #include <linux/mm.h>
+#include <linux/dma-buf.h>
+#include <linux/scatterlist.h>
+#include <linux/slab.h>
 #include <linux/time.h>
 #include <linux/module.h>
 #include <linux/videodev2.h>
@@ -87,6 +90,13 @@ MODULE_VERSION("" __stringify(V4L2LOOPBACK_VERSION_MAJOR) "." __stringify(
 	V4L2LOOPBACK_VERSION_MINOR) "." __stringify(V4L2LOOPBACK_VERSION_BUGFIX));
 #endif
 MODULE_LICENSE("GPL");
+
+/* Required to use dma_buf_export()/dma_buf_fd() for the EXPBUF exporter. */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
+MODULE_IMPORT_NS("DMA_BUF");
+#else
+MODULE_IMPORT_NS(DMA_BUF);
+#endif
 
 /*
  * helpers
@@ -1671,7 +1681,9 @@ static int vidioc_reqbufs(struct file *file, void *fh,
 	switch (reqbuf->memory) {
 	case V4L2_MEMORY_MMAP:
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 20, 0)
-		reqbuf->capabilities = 0; /* only guarantee MMAP support */
+		/* MMAP buffers can also be exported as dma-bufs (VIDIOC_EXPBUF). */
+		reqbuf->capabilities = V4L2_BUF_CAP_SUPPORTS_MMAP |
+				       V4L2_BUF_CAP_SUPPORTS_DMABUF;
 #endif
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 16, 0)
 		reqbuf->flags = 0; /* no memory consistency support */
@@ -2222,6 +2234,210 @@ static struct vm_operations_struct vm_ops = {
 	.open = vm_open,
 	.close = vm_close,
 };
+
+/*
+ * DMABUF exporter. VIDIOC_EXPBUF wraps a buffer's vmalloc pages (from
+ * dev->image) as a dma-buf so a consumer can import it zero-copy instead of
+ * mmap+memcpy. The sg_table is built with vmalloc_to_page().
+ */
+struct v4l2l_dmabuf {
+	u8 *vaddr;       /* dev->image + offset */
+	unsigned long size;
+	unsigned int n_pages;
+	struct page **pages;
+};
+
+static struct v4l2l_dmabuf *v4l2l_dmabuf_alloc(u8 *vaddr, unsigned long size)
+{
+	struct v4l2l_dmabuf *d;
+	unsigned int i;
+
+	d = kzalloc(sizeof(*d), GFP_KERNEL);
+	if (!d)
+		return NULL;
+
+	d->vaddr = vaddr;
+	d->size = PAGE_ALIGN(size);
+	d->n_pages = d->size >> PAGE_SHIFT;
+	d->pages = kcalloc(d->n_pages, sizeof(*d->pages), GFP_KERNEL);
+	if (!d->pages) {
+		kfree(d);
+		return NULL;
+	}
+
+	for (i = 0; i < d->n_pages; i++) {
+		d->pages[i] = vmalloc_to_page(vaddr + (i << PAGE_SHIFT));
+		if (!d->pages[i]) {
+			while (i--)
+				put_page(d->pages[i]);
+			kfree(d->pages);
+			kfree(d);
+			return NULL;
+		}
+		/*
+		 * Pin each page so the exported dma-buf survives vfree() of
+		 * dev->image. vfree() frees pages only at refcount 0, so the
+		 * extra ref keeps them alive until v4l2l_dmabuf_release().
+		 */
+		get_page(d->pages[i]);
+	}
+	return d;
+}
+
+static struct sg_table *v4l2l_dmabuf_map(struct dma_buf_attachment *att,
+					 enum dma_data_direction dir)
+{
+	struct v4l2l_dmabuf *d = att->dmabuf->priv;
+	struct sg_table *sgt;
+	int ret;
+
+	sgt = kzalloc(sizeof(*sgt), GFP_KERNEL);
+	if (!sgt)
+		return ERR_PTR(-ENOMEM);
+
+	ret = sg_alloc_table_from_pages(sgt, d->pages, d->n_pages, 0,
+					d->size, GFP_KERNEL);
+	if (ret) {
+		kfree(sgt);
+		return ERR_PTR(ret);
+	}
+
+	ret = dma_map_sgtable(att->dev, sgt, dir, 0);
+	if (ret) {
+		sg_free_table(sgt);
+		kfree(sgt);
+		return ERR_PTR(ret);
+	}
+	return sgt;
+}
+
+static void v4l2l_dmabuf_unmap(struct dma_buf_attachment *att,
+			       struct sg_table *sgt, enum dma_data_direction dir)
+{
+	dma_unmap_sgtable(att->dev, sgt, dir, 0);
+	sg_free_table(sgt);
+	kfree(sgt);
+}
+
+static int v4l2l_dmabuf_mmap(struct dma_buf *dmabuf, struct vm_area_struct *vma)
+{
+	struct v4l2l_dmabuf *d = dmabuf->priv;
+	unsigned long start = vma->vm_start;
+	unsigned long size = vma->vm_end - vma->vm_start;
+	unsigned long pgoff = vma->vm_pgoff;
+	unsigned int i;
+	int ret;
+
+	if (pgoff + (size >> PAGE_SHIFT) > d->n_pages)
+		return -EINVAL;
+
+	for (i = pgoff; i < d->n_pages && size > 0; i++) {
+		ret = vm_insert_page(vma, start, d->pages[i]);
+		if (ret)
+			return ret;
+		start += PAGE_SIZE;
+		size -= PAGE_SIZE;
+	}
+	return 0;
+}
+
+/* Drop the page pins taken in v4l2l_dmabuf_alloc() and free the wrapper. */
+static void v4l2l_dmabuf_free(struct v4l2l_dmabuf *d)
+{
+	unsigned int i;
+
+	for (i = 0; i < d->n_pages; i++)
+		put_page(d->pages[i]);
+	kfree(d->pages);
+	kfree(d);
+}
+
+static void v4l2l_dmabuf_release(struct dma_buf *dmabuf)
+{
+	v4l2l_dmabuf_free(dmabuf->priv);
+}
+
+static const struct dma_buf_ops v4l2l_dmabuf_ops = {
+	.map_dma_buf = v4l2l_dmabuf_map,
+	.unmap_dma_buf = v4l2l_dmabuf_unmap,
+	.mmap = v4l2l_dmabuf_mmap,
+	.release = v4l2l_dmabuf_release,
+};
+
+static int vidioc_expbuf(struct file *file, void *fh,
+			 struct v4l2_exportbuffer *eb)
+{
+	struct v4l2_loopback_device *dev = v4l2loopback_getdevice(file);
+	struct v4l2_loopback_opener *opener = v4l2l_f_to_opener(file, fh);
+	DEFINE_DMA_BUF_EXPORT_INFO(exp_info);
+	struct v4l2l_dmabuf *d;
+	struct dma_buf *dmabuf;
+	unsigned long offset;
+	int fd;
+	int ret;
+
+	if (eb->type != V4L2_BUF_TYPE_VIDEO_CAPTURE &&
+	    eb->type != V4L2_BUF_TYPE_VIDEO_OUTPUT)
+		return -EINVAL;
+	if (eb->plane != 0)
+		return -EINVAL;
+	/*
+	 * Accept only O_CLOEXEC and the access mode. The access mode is
+	 * honored for our own exports. A pass-through dma-buf keeps the
+	 * producer's mode.
+	 */
+	if (eb->flags & ~(O_CLOEXEC | O_ACCMODE))
+		return -EINVAL;
+	/* same ownership check as QUERYBUF, the caller must own this buffer */
+	if (!is_allocated(opener, eb->type, eb->index))
+		return -EINVAL;
+
+	ret = mutex_lock_killable(&dev->image_mutex);
+	if (ret < 0)
+		return ret;
+
+	if (!dev->image || eb->index >= dev->buffer_count ||
+	    dev->buffer_size == 0) {
+		ret = -EINVAL;
+		goto unlock;
+	}
+	offset = (unsigned long)eb->index * dev->buffer_size;
+	if (offset + dev->buffer_size > dev->image_size) {
+		ret = -EINVAL;
+		goto unlock;
+	}
+
+	d = v4l2l_dmabuf_alloc(dev->image + offset, dev->buffer_size);
+	if (!d) {
+		ret = -ENOMEM;
+		goto unlock;
+	}
+
+	exp_info.ops = &v4l2l_dmabuf_ops;
+	exp_info.size = d->size;
+	exp_info.flags = eb->flags & O_ACCMODE;
+	exp_info.priv = d;
+
+	dmabuf = dma_buf_export(&exp_info);
+	if (IS_ERR(dmabuf)) {
+		v4l2l_dmabuf_free(d);
+		ret = PTR_ERR(dmabuf);
+		goto unlock;
+	}
+
+	fd = dma_buf_fd(dmabuf, eb->flags & O_CLOEXEC);
+	if (fd < 0) {
+		dma_buf_put(dmabuf);
+		ret = fd;
+		goto unlock;
+	}
+	eb->fd = fd;
+	ret = 0;
+
+unlock:
+	mutex_unlock(&dev->image_mutex);
+	return ret;
+}
 
 static int v4l2_loopback_mmap(struct file *file, struct vm_area_struct *vma)
 {
@@ -3222,6 +3438,7 @@ static const struct v4l2_ioctl_ops v4l2_loopback_ioctl_ops = {
 	.vidioc_querybuf		= &vidioc_querybuf,
 	.vidioc_qbuf			= &vidioc_qbuf,
 	.vidioc_dqbuf			= &vidioc_dqbuf,
+	.vidioc_expbuf			= &vidioc_expbuf,
 
 	.vidioc_streamon		= &vidioc_streamon,
 	.vidioc_streamoff		= &vidioc_streamoff,

--- a/v4l2loopback.c
+++ b/v4l2loopback.c
@@ -339,6 +339,7 @@ struct v4l2l_buffer {
 	struct v4l2_buffer buffer;
 	struct list_head list_head;
 	atomic_t use_count;
+	struct dma_buf *import_dbuf;
 };
 
 struct v4l2_loopback_device {
@@ -1653,8 +1654,8 @@ exit_prepare_queue_unlock:
 }
 
 /* forward declaration */
-static int vidioc_streamoff(struct file *file, void *fh,
-			    enum v4l2_buf_type type);
+static int do_streamoff(struct file *file, void *fh, enum v4l2_buf_type type);
+static void release_import_dbufs_locked(struct v4l2_loopback_device *dev);
 /* negotiate buffer type
  * only mmap streaming supported
  * called on VIDIOC_REQBUFS
@@ -1689,6 +1690,18 @@ static int vidioc_reqbufs(struct file *file, void *fh,
 		reqbuf->flags = 0; /* no memory consistency support */
 #endif
 		break;
+	case V4L2_MEMORY_DMABUF:
+		/*
+		 * Zero-copy injection, only on the OUTPUT (producer) queue. The
+		 * buffer slots still come from the normal allocation. QBUF
+		 * imports a producer dma-buf into the slot instead of copying.
+		 */
+		if (reqbuf->type != V4L2_BUF_TYPE_VIDEO_OUTPUT)
+			return -EINVAL;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 20, 0)
+		reqbuf->capabilities = V4L2_BUF_CAP_SUPPORTS_DMABUF;
+#endif
+		break;
 	default:
 		return -EINVAL;
 	}
@@ -1718,7 +1731,13 @@ static int vidioc_reqbufs(struct file *file, void *fh,
 			acquire_token(dev, opener, format, token);
 			opener->io_method = V4L2L_IO_MMAP;
 		}
-		result = vidioc_streamoff(file, fh, reqbuf->type);
+		result = do_streamoff(file, fh, reqbuf->type);
+		/*
+		 * Release imports here while image_mutex is held. do_streamoff()
+		 * cannot, and this also covers close() via REQBUFS(0).
+		 */
+		if (reqbuf->type == V4L2_BUF_TYPE_VIDEO_OUTPUT)
+			release_import_dbufs_locked(dev);
 		opener->buffer_count = 0;
 		/* undocumented requirement - REQBUFS with count zero should
 		 * ALSO release lock on logical stream */
@@ -1867,6 +1886,7 @@ static int vidioc_qbuf(struct file *file, void *fh, struct v4l2_buffer *buf)
 	struct v4l2l_buffer *bufd;
 	u32 index = buf->index;
 	u32 type = buf->type;
+	u32 memory = buf->memory;
 
 	if (!is_allocated(opener, type, index))
 		return -EINVAL;
@@ -1876,6 +1896,11 @@ static int vidioc_qbuf(struct file *file, void *fh, struct v4l2_buffer *buf)
 	case V4L2_MEMORY_MMAP:
 		if (!(bufd->buffer.flags & V4L2_BUF_FLAG_MAPPED))
 			dprintkrw("QBUF() unmapped buffer [index=%u]\n", index);
+		break;
+	case V4L2_MEMORY_DMABUF:
+		/* Zero-copy injection: OUTPUT (producer) queue only. */
+		if (type != V4L2_BUF_TYPE_VIDEO_OUTPUT)
+			return -EINVAL;
 		break;
 	default:
 		return -EINVAL;
@@ -1895,6 +1920,49 @@ static int vidioc_qbuf(struct file *file, void *fh, struct v4l2_buffer *buf)
 	case V4L2_BUF_TYPE_VIDEO_OUTPUT:
 		dprintkrw("QBUF(OUTPUT, index=%u) -> " BUFFER_DEBUG_FMT_STR,
 			  index, BUFFER_DEBUG_FMT_ARGS(buf));
+		if (buf->memory == V4L2_MEMORY_DMABUF) {
+			/*
+			 * Use the producer's dma-buf as this slot's frame
+			 * instead of copying into dev->image. The ref is
+			 * released when the slot is re-queued or freed.
+			 */
+			struct dma_buf *db = dma_buf_get(buf->m.fd);
+			struct dma_buf *old;
+
+			if (IS_ERR(db)) {
+				dprintkrw("QBUF(OUTPUT) bad dmabuf fd %d\n",
+					  buf->m.fd);
+				return -EINVAL;
+			}
+			/*
+			 * image_mutex serializes import_dbuf against EXPBUF and
+			 * free_buffers(). Put the old ref outside the lock.
+			 */
+			mutex_lock(&dev->image_mutex);
+			if (db->size < dev->buffer_size) {
+				mutex_unlock(&dev->image_mutex);
+				dma_buf_put(db);
+				return -EINVAL;
+			}
+			old = bufd->import_dbuf;
+			bufd->import_dbuf = db;
+			mutex_unlock(&dev->image_mutex);
+			if (old)
+				dma_buf_put(old);
+		} else if (bufd->import_dbuf) {
+			/*
+			 * Filled from dev->image now, so drop any stale import
+			 * or EXPBUF would re-export the old producer frame.
+			 */
+			struct dma_buf *old;
+
+			mutex_lock(&dev->image_mutex);
+			old = bufd->import_dbuf;
+			bufd->import_dbuf = NULL;
+			mutex_unlock(&dev->image_mutex);
+			if (old)
+				dma_buf_put(old);
+		}
 		if (!(bufd->buffer.flags & V4L2_BUF_FLAG_TIMESTAMP_COPY) &&
 		    (buf->timestamp.tv_sec == 0 &&
 		     buf->timestamp.tv_usec == 0)) {
@@ -1935,6 +2003,7 @@ static int vidioc_qbuf(struct file *file, void *fh, struct v4l2_buffer *buf)
 		return -EINVAL;
 	}
 	buf->type = type;
+	buf->memory = memory;
 	return 0;
 }
 
@@ -2016,11 +2085,17 @@ static int vidioc_dqbuf(struct file *file, void *fh, struct v4l2_buffer *buf)
 	struct v4l2_loopback_device *dev = v4l2loopback_getdevice(file);
 	struct v4l2_loopback_opener *opener = v4l2l_f_to_opener(file, fh);
 	u32 type = buf->type;
+	u32 memory = buf->memory;
 	int index;
 	struct v4l2l_buffer *bufd;
 
-	if (buf->memory != V4L2_MEMORY_MMAP)
-		return -EINVAL;
+	if (buf->memory != V4L2_MEMORY_MMAP) {
+		/* Allow the producer to dequeue DMABUF buffers on the OUTPUT
+		 * queue so it can recycle slots after a frame is consumed. */
+		if (!(buf->memory == V4L2_MEMORY_DMABUF &&
+		      type == V4L2_BUF_TYPE_VIDEO_OUTPUT))
+			return -EINVAL;
+	}
 	if (opener->format_token & V4L2L_TOKEN_TIMEOUT) {
 		*buf = dev->timeout_buffer.buffer;
 		buf->type = type;
@@ -2052,16 +2127,35 @@ static int vidioc_dqbuf(struct file *file, void *fh, struct v4l2_buffer *buf)
 			return -EFAULT;
 		unset_flags(bufd->buffer.flags);
 		*buf = bufd->buffer;
+		index = bufd->buffer.index;
 		break;
 	default:
 		return -EINVAL;
 	}
 
 	buf->type = type;
+	buf->memory = memory;
 	dprintkrw("DQBUF(%s, index=%u) -> " BUFFER_DEBUG_FMT_STR,
 		  V4L2_TYPE_IS_CAPTURE(type) ? "CAPTURE" : "OUTPUT", index,
 		  BUFFER_DEBUG_FMT_ARGS(buf));
 	return 0;
+}
+
+/* Release all imported (DMABUF-OUTPUT) frames still held on buffer slots.
+ * Caller must hold dev->image_mutex (serializes against QBUF/DQBUF/EXPBUF).
+ */
+static void release_import_dbufs_locked(struct v4l2_loopback_device *dev)
+{
+	int i;
+
+	for (i = 0; i < dev->buffer_count; i++) {
+		struct dma_buf *db = dev->buffers[i].import_dbuf;
+
+		if (db) {
+			dev->buffers[i].import_dbuf = NULL;
+			dma_buf_put(db);
+		}
+	}
 }
 
 /* ------------- STREAMING ------------------- */
@@ -2103,8 +2197,7 @@ static int vidioc_streamon(struct file *file, void *fh, enum v4l2_buf_type type)
 /* stop streaming
  * called on VIDIOC_STREAMOFF
  */
-static int vidioc_streamoff(struct file *file, void *fh,
-			    enum v4l2_buf_type type)
+static int do_streamoff(struct file *file, void *fh, enum v4l2_buf_type type)
 {
 	struct v4l2_loopback_device *dev = v4l2loopback_getdevice(file);
 	struct v4l2_loopback_opener *opener = v4l2l_f_to_opener(file, fh);
@@ -2139,6 +2232,25 @@ static int vidioc_streamoff(struct file *file, void *fh,
 	default:
 		return -EINVAL;
 	}
+}
+
+/*
+ * STREAMOFF ioctl entry. Runs do_streamoff() and releases imported OUTPUT
+ * frames (V4L2 unlocks all buffers on STREAMOFF). image_mutex is taken here
+ * since the ioctl path, unlike vidioc_reqbufs(), does not already hold it.
+ */
+static int vidioc_streamoff(struct file *file, void *fh,
+			    enum v4l2_buf_type type)
+{
+	struct v4l2_loopback_device *dev = v4l2loopback_getdevice(file);
+	int ret = do_streamoff(file, fh, type);
+
+	if (!ret && type == V4L2_BUF_TYPE_VIDEO_OUTPUT) {
+		mutex_lock(&dev->image_mutex);
+		release_import_dbufs_locked(dev);
+		mutex_unlock(&dev->image_mutex);
+	}
+	return ret;
 }
 
 #ifdef CONFIG_VIDEO_V4L1_COMPAT
@@ -2401,6 +2513,26 @@ static int vidioc_expbuf(struct file *file, void *fh,
 		ret = -EINVAL;
 		goto unlock;
 	}
+	/*
+	 * If the slot was filled by DMABUF import, hand the consumer that
+	 * same dma-buf (a fresh fd) instead of wrapping dev->image, so the
+	 * producer's pages pass through with no copy.
+	 */
+	if (dev->buffers[eb->index].import_dbuf) {
+		struct dma_buf *db = dev->buffers[eb->index].import_dbuf;
+
+		get_dma_buf(db);
+		fd = dma_buf_fd(db, eb->flags & O_CLOEXEC);
+		if (fd < 0) {
+			dma_buf_put(db);
+			ret = fd;
+			goto unlock;
+		}
+		eb->fd = fd;
+		ret = 0;
+		goto unlock;
+	}
+
 	offset = (unsigned long)eb->index * dev->buffer_size;
 	if (offset + dev->buffer_size > dev->image_size) {
 		ret = -EINVAL;
@@ -2762,6 +2894,8 @@ static ssize_t v4l2_loopback_write(struct file *file, const char __user *buf,
 static void free_buffers(struct v4l2_loopback_device *dev)
 {
 	dprintk("free_buffers() with image@%p\n", dev->image);
+	/* Release any imported (DMABUF-OUTPUT) frames held on buffer slots. */
+	release_import_dbufs_locked(dev);
 	if (!dev->image)
 		return;
 	if (!has_no_owners(dev) || any_mapped_buffer(dev))


### PR DESCRIPTION
This adds dma-buf support to v4l2loopback so frames can move through the device
without a CPU copy. It is the feature requested in #501.

Three parts:

- VIDIOC_EXPBUF exports a loopback buffer as a dma-buf, so a consumer can import
  it instead of doing mmap plus memcpy.
- DMABUF import on the OUTPUT queue lets a producer REQBUFS with
  V4L2_MEMORY_DMABUF and QBUF a dma-buf fd as the frame, instead of copying into
  the internal image.
- DMABUF dequeue on the OUTPUT queue lets the producer recycle its slots once a
  frame has been consumed.

When the OUTPUT slot was filled by a dma-buf, EXPBUF hands the consumer that same
dma-buf, so the frame passes through with no copy in either direction.

## Scope

The zero-copy OUTPUT path is meant to be paired with a dma-buf aware consumer
that uses EXPBUF. A consumer that reads through plain read or mmap still reads
the internal image and will not see a frame injected by reference. The exporter
handles a single plane.

## How to reproduce

Load the module and a dma-buf capable test source. vivid gives a capture node
that exports dma-bufs, here at /dev/video2.

    sudo modprobe v4l2loopback video_nr=10 card_label=loopback
    sudo modprobe vivid

Export loopback frames as dma-bufs (drives VIDIOC_EXPBUF). The ffmpeg line is a
plain copy that fills the loopback with no dma-buf involved. The gst-launch line
then reads those frames back out as dma-bufs, which is the part that uses EXPBUF.

    ffmpeg -f v4l2 -i /dev/video2 -codec copy -f v4l2 /dev/video10
    gst-launch-1.0 v4l2src device=/dev/video10 io-mode=dmabuf num-buffers=60 ! fakesink

Inject dma-bufs and read them back zero-copy (drives the OUTPUT import and the
EXPBUF passthrough).

    gst-launch-1.0 v4l2src device=/dev/video2 io-mode=dmabuf ! video/x-raw,format=YUY2,width=640,height=480 ! v4l2sink device=/dev/video10 io-mode=dmabuf-import
    gst-launch-1.0 v4l2src device=/dev/video10 io-mode=dmabuf num-buffers=60 ! fakesink

io-mode=dmabuf makes v4l2src export with EXPBUF and io-mode=dmabuf-import makes
v4l2sink import into the OUTPUT queue. vivid is happy with the caps filter above.
A UVC camera like the C920 negotiates better with no caps filter at all. Both
pipelines ran here with 60 frames and a clean exit.

## Testing

The series also adds a standalone self-test, tests/test_dmabuf.c, that exercises
the export and import paths in a single process with no camera or second
pipeline. It fills an MMAP buffer, exports it and checks the dma-buf maps the
same pixels, then re-requests the queue as DMABUF, queues the exported fd back
in, and checks QBUF, DQBUF, the pass-through EXPBUF, and that the DMABUF memory
type is preserved.

    sudo modprobe v4l2loopback video_nr=10
    cd tests && make && ./test_dmabuf /dev/video10

It passes on a 6.x kernel and on 5.15, and the module builds without new warnings
on both.
